### PR TITLE
Update migrations for tagTitle

### DIFF
--- a/db/migrations/20180102140611_update_discussions.js
+++ b/db/migrations/20180102140611_update_discussions.js
@@ -1,0 +1,13 @@
+/* eslint-disable */
+
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table('discussions', function(table) {
+      table.string('tagTitle');
+    }),
+  ]);
+};
+
+exports.down = function(knex, Promise) {
+  knex.schema.dropTable('discussions')
+};

--- a/db/seeds/dev/complex-discussions.js
+++ b/db/seeds/dev/complex-discussions.js
@@ -32,6 +32,7 @@ const createTopicTag = (knex, topic) => {
           title: discussion.title,
           body: discussion.body,
           tagId: topicTagId[0],
+          tagTitle: discussion.tagTitle,
         }));
       });
       return Promise.all(discussionPromises);
@@ -63,6 +64,7 @@ const discussionsData = [
     discussions: [
       {
         id: 1,
+        tagTitle: "6.RP.A.1",
         title: "Unit Rate",
         body: "Didn't kids get this in Grade 5? I'm confused about why it's in the standards.",
         comments: [
@@ -84,6 +86,7 @@ const discussionsData = [
     discussions: [
       {
         id: 2,
+        tagTitle: "6.RP.A.2",
         title: "Tape Diagrams",
         body: "I'm having a hard time grasping tape diagrams well enough to teach kids how to use them as a tool. Any resources?",
         comments: [
@@ -95,6 +98,7 @@ const discussionsData = [
       },
       {
         id: 3,
+        tagTitle: "6.RP.A.2",
         title: "Double number line",
         body: "I get it, but I'm struggling to find the words to explain this without getting too procedural. Any tips?",
         comments: [
@@ -112,6 +116,7 @@ const discussionsData = [
     discussions: [
       {
         id: 4,
+        tagTitle: "6.RP.A.3",
         title: "Coodinate Plane",
         body: "Should students already know how to plot points on a coordinate plane?.",
         comments: [
@@ -129,6 +134,7 @@ const discussionsData = [
     discussions: [
       {
         id: 5,
+        tagTitle: "6.RP.A.3.A",
         title: "Percent",
         body: "I'm looking for great percent (with part, whole vocab) anchor charts - any pictures?",
         comments: [
@@ -144,6 +150,7 @@ const discussionsData = [
       },
       {
         id: 6,
+        tagTitle: "6.RP.A.3.A",
         title: "Measurement",
         body: "Specifically what units do we care about converting? Should students have ratios memorized, or can we assume they just need to understand how the two units compare and perform the conversion?",
         comments: [
@@ -161,6 +168,7 @@ const discussionsData = [
     discussions: [
       {
         id: 7,
+        tagTitle: "6.RP.A.3.B",
         title: "Dividing Fractions",
         body: "Specifically what units do we care about converting? Should students have ratios memorized, or can we assume they just need to understand how the two units compare and perform the conversion?",
         comments: [
@@ -182,6 +190,7 @@ const discussionsData = [
     discussions: [
       {
         id: 8,
+        tagTitle: "6.RP.A.3.C",
         title: "GCF LCM Visuals",
         body: "Any great visuals for GCF and LCM?",
         comments: [
@@ -203,6 +212,7 @@ const discussionsData = [
     discussions: [
       {
         id: 9,
+        tagTitle: "6.NS.A.1",
         title: "Absolute Value",
         body: "What hands-on activities do you recommend for teaching this?",
         comments: [
@@ -220,6 +230,7 @@ const discussionsData = [
     discussions: [
       {
         id: 10,
+        tagTitle: "6.NS.B.2",
         title: "Tasks",
         body: "Any great real-world tasks involving coordinate plane?",
         comments: [
@@ -231,6 +242,7 @@ const discussionsData = [
       },
       {
         id: 11,
+        tagTitle: "6.NS.B.2",
         title: "Variable - vocab",
         body: "Should students be using the term 'variables'? The standard says '... in which letters stand for numbers'.",
         comments: [
@@ -248,6 +260,7 @@ const discussionsData = [
     discussions: [
       {
         id: 12,
+        tagTitle: "6.NS.B.3",
         title: "Subtract y from 5",
         body: "What kind of think-alouds or exploratory tasks, etc. can be done to help students see that 'subtract y from 5' = 5 - y and not y - 5? Thanks!",
         comments: [
@@ -265,6 +278,7 @@ const discussionsData = [
     discussions: [
       {
         id: 13,
+        tagTitle: "6.NS.B.3",
         title: "Vocab strategies",
         body: "Does anyone have a fun way of reinforcing vocabulary?",
         comments: [
@@ -282,6 +296,7 @@ const discussionsData = [
     discussions: [
       {
         id: 14,
+        tagTitle: "6.NS.B.4",
         title: "Factoring out of Distributive Property",
         body: "How do you teach kids to factor out an expression such as 24x + 18? I can 'drill and kill' a procedure, but I'd love to teach it in a better way.",
         comments: [
@@ -299,6 +314,7 @@ const discussionsData = [
     discussions: [
       {
         id: 15,
+        tagTitle: "6.NS.C.5",
         title: "Equations?",
         body: "How many step - equations should we have them solve?",
         comments: [
@@ -316,6 +332,7 @@ const discussionsData = [
     discussions: [
       {
         id: 16,
+        tagTitle: "6.NS.C.6",
         title: "Dependent/Independent",
         body: "How can we collaborate with the science team to reinforce dependent/independent variables?",
         comments: [
@@ -327,6 +344,7 @@ const discussionsData = [
       },
       {
         id: 17,
+        tagTitle: "6.NS.C.6",
         title: "ELL - vocab",
         body: "This is especially difficult for my students who are ELLs. ANy strategies to help them?",
         comments: [],
@@ -339,6 +357,7 @@ const discussionsData = [
     discussions: [
       {
         id: 18,
+        tagTitle: "6.NS.C.6.A",
         title: "Dependent/Independent",
         body: "How can we collaborate with the science team to reinforce dependent/independent variables?",
         comments: [
@@ -356,6 +375,7 @@ const discussionsData = [
     discussions: [
       {
         id: 19,
+        tagTitle: "6.NS.C.6.B",
         title: "Variables",
         body: "How do you represent variables with algeblocks?",
         comments: [
@@ -373,6 +393,7 @@ const discussionsData = [
     discussions: [
       {
         id: 20,
+        tagTitle: "6.NS.C.6.C",
         title: "This is completely made up",
         body: "BAHHHHHH",
         comments: [
@@ -390,6 +411,7 @@ const discussionsData = [
     discussions: [
       {
         id: 21,
+        tagTitle: "6.NS.C.7",
         title: "3D Nets",
         body: "I know this isn't a prioritized standard, but would love to do this on a culture day - any fun activities out there?",
         comments: [
@@ -407,6 +429,7 @@ const discussionsData = [
     discussions: [
       {
         id: 22,
+        tagTitle: "6.NS.C.7.A",
         title: "Data - overall shape",
         body: "How far should we go into 'overall shape'?",
         comments: [
@@ -428,6 +451,7 @@ const discussionsData = [
     discussions: [
       {
         id: 23,
+        tagTitle: "6.NS.C.7.B",
         title: "Central Tend - Graphic Organizers",
         body: "Any good graphic organizers for all the measures of central tendency?",
         comments: [
@@ -445,6 +469,7 @@ const discussionsData = [
     discussions: [
       {
         id: 24,
+        tagTitle: "6.NS.C.7.B",
         title: "Which data display to prioritize?",
         body: "I only have time to cover two: dot, histogram, or box plots? What's more importnat for 7th-8th?",
         comments: [
@@ -462,6 +487,7 @@ const discussionsData = [
     discussions: [
       {
         id: 25,
+        tagTitle: "6.NS.C.7.C",
         title: "Anchor charts",
         body: "Who has great anchor charts I can borrow ideas from? I'm not creative!",
         comments: [
@@ -479,6 +505,7 @@ const discussionsData = [
     discussions: [
       {
         id: 26,
+        tagTitle: "6.NS.C.7.D",
         title: "Curriculum order",
         body: "Does it make sense to teach RP standars before NS?",
         comments: [
@@ -496,6 +523,7 @@ const discussionsData = [
     discussions: [
       {
         id: 27,
+        tagTitle: "6.NS.C.8",
         title: "Fluency",
         body: "Does anyone have any great fluency activities?",
         comments: [
@@ -513,6 +541,7 @@ const discussionsData = [
     discussions: [
       {
         id: 28,
+        tagTitle: "6.NS.EE.A.1",
         title: "Fluency",
         body: "Does anyone have any great fluency activities?",
         comments: [],
@@ -525,6 +554,7 @@ const discussionsData = [
     discussions: [
       {
         id: 29,
+        tagTitle: "6.EE.A.2",
         title: "Packet format?",
         body: "How do you format your packets? Looking for something I can use daily - consistent and quick.",
         comments: [
@@ -542,6 +572,7 @@ const discussionsData = [
     discussions: [
       {
         id: 30,
+        tagTitle: "6.EE.A.2.A",
         title: "Packet content",
         body: "What all do you print in your packet? If I print too much, the kids work ahead. Ideas?",
         comments: [
@@ -559,6 +590,7 @@ const discussionsData = [
     discussions: [
       {
         id: 31,
+        tagTitle: "6.EE.A.2.B",
         title: "Grading DN",
         body: "Do you grade Do Nows?",
         comments: [
@@ -576,6 +608,7 @@ const discussionsData = [
     discussions: [
       {
         id: 32,
+        tagTitle: "6.EE.A.2.C",
         title: "Trade and Grade",
         body: "Any trade and grade strategies? I would love to see a video of the executiong.",
         comments: [
@@ -593,6 +626,7 @@ const discussionsData = [
     discussions: [
       {
         id: 33,
+        tagTitle: "6.EE.A.3",
         title: "Precise Language",
         body: "How are teachers getting students to use precise mathematical vocab?",
         comments: [
@@ -610,6 +644,7 @@ const discussionsData = [
     discussions: [
       {
         id: 34,
+        tagTitle: "6.EE.A.4",
         title: "Partners",
         body: "How do you pair kids up? I'm noticing that students farther along are steamrolling kids who need to be supported by that peer.",
         comments: [],


### PR DESCRIPTION
Discussions table now hold tagTitle, which will allow us to filter by tags.
TagTitles are also now inside of the discussion object in seed data