### PR TITLE
Remove check auth from comment post

### DIFF
--- a/server.js
+++ b/server.js
@@ -228,7 +228,7 @@ app.get('/api/v1/discussions/:id/comments', (request, response) => {
     .catch(error => response.status(500).json({ error }));
 });
 
-app.post('/api/v1/discussions/:id/comments', checkAuth, (request, response) => {
+app.post('/api/v1/discussions/:id/comments', (request, response) => {
   let comment = request.body;
   const { id } = request.params;
 


### PR DESCRIPTION
Removed check auth from the comment post for the sake of development. Let's discuss more as to whether or not we want to remove it completely in order to increase user access. 